### PR TITLE
Create API unit and integration tests

### DIFF
--- a/src/test/java/com/ss/stationapi/MbtaApplicationTests.java
+++ b/src/test/java/com/ss/stationapi/MbtaApplicationTests.java
@@ -1,58 +1,101 @@
 package com.ss.stationapi;
 
 import com.ss.stationapi.model.StationInfo;
+import com.ss.stationapi.service.StationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 
-
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
-/**
- * Integration tests for the MBTA Station API.
- * These tests check the basic functionality of the API endpoints.
- */
 class MbtaApplicationTests {
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @MockBean
+    private StationService stationService;
+
+    private StationInfo station(String id, String name, String... lines) {
+        StationInfo s = new StationInfo();
+        s.setId(id);
+        s.setName(name);
+        for (String line : lines) {
+            s.addLine(line);
+        }
+        return s;
+    }
+
+    @BeforeEach
+    void setupMocks() {
+        Map<String, StationInfo> all = new LinkedHashMap<>();
+        all.put("stop-1", station("stop-1", "Station One", "Red", "Blue"));
+        all.put("stop-2", station("stop-2", "Station Two", "Green"));
+
+        given(stationService.getStationInfo_v2()).willReturn(all);
+        given(stationService.getStationInfoById("stop-1")).willReturn(all.get("stop-1"));
+        given(stationService.getStationInfoById("stop-2")).willReturn(all.get("stop-2"));
+        given(stationService.getStationInfoById("nonexistent-stop")).willReturn(null);
+
+        given(stationService.linesByStation_v2("stop-1")).willReturn(new LinkedHashSet<>(Arrays.asList("Red", "Blue")));
+        given(stationService.linesByStation_v2("stop-2")).willReturn(Collections.emptySet());
+    }
 
     @Test
     void contextLoads() {
     }
 
     @Test
-    void testGetAllStations() {
+    void getAllStations_returnsExpectedData() {
         ResponseEntity<Map> response = restTemplate.getForEntity("/api/v1/stations", Map.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().size()).isGreaterThan(0);
+        assertThat(response.getBody()).containsKeys("stop-1", "stop-2");
     }
 
     @Test
-    void testGetStationById_found() {
-        // Replace "place-alfcl" with a known stopId in your dataset
-        String stopId = "place-alfcl";
-        ResponseEntity<StationInfo> response = restTemplate.getForEntity("/api/v1/stations/" + stopId, StationInfo.class);
-        // Accept 200 or 404 depending on data load
-        assertThat(response.getStatusCode()).isIn(HttpStatus.OK, HttpStatus.NOT_FOUND);
-        if (response.getStatusCode() == HttpStatus.OK) {
-            assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().getId()).isEqualTo(stopId);
-        }
+    void getStationById_found() {
+        ResponseEntity<StationInfo> response = restTemplate.getForEntity("/api/v1/stations/stop-1", StationInfo.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isEqualTo("stop-1");
     }
 
     @Test
-    void testGetStationById_notFound() {
-        String stopId = "nonexistent-stop";
-        ResponseEntity<StationInfo> response = restTemplate.getForEntity("/api/v1/stations/" + stopId, StationInfo.class);
+    void getStationById_notFound() {
+        ResponseEntity<StationInfo> response = restTemplate.getForEntity("/api/v1/stations/nonexistent-stop", StationInfo.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void getLinesByStation_found() {
+        ResponseEntity<List> response = restTemplate.getForEntity("/api/v1/stations/stop-1/lines", List.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsExactly("Red", "Blue");
+    }
+
+    @Test
+    void getLinesByStation_notFound() {
+        ResponseEntity<List> response = restTemplate.getForEntity("/api/v1/stations/stop-2/lines", List.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void rootAndHealthEndpoints() {
+        ResponseEntity<String> root = restTemplate.getForEntity("/", String.class);
+        assertThat(root.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(root.getBody()).contains("MBTA Analyzer API is running");
+
+        ResponseEntity<String> health = restTemplate.getForEntity("/health", String.class);
+        assertThat(health.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(health.getBody()).isEqualTo("OK");
     }
 }

--- a/src/test/java/com/ss/stationapi/controller/DefaultControllerTest.java
+++ b/src/test/java/com/ss/stationapi/controller/DefaultControllerTest.java
@@ -1,0 +1,30 @@
+package com.ss.stationapi.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DefaultController.class)
+class DefaultControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void home_returnsMessage() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("MBTA Analyzer API is running. Use /api/v1/stations for data."));
+    }
+
+    @Test
+    void health_returnsOk() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("OK"));
+    }
+}

--- a/src/test/java/com/ss/stationapi/controller/StationControllerTest.java
+++ b/src/test/java/com/ss/stationapi/controller/StationControllerTest.java
@@ -1,0 +1,90 @@
+package com.ss.stationapi.controller;
+
+import com.ss.stationapi.model.StationInfo;
+import com.ss.stationapi.service.StationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.*;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(StationController.class)
+class StationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StationService stationService;
+
+    private StationInfo buildStation(String id, String name, double lat, double lon, String... lines) {
+        StationInfo s = new StationInfo();
+        s.setId(id);
+        s.setName(name);
+        s.setLatitude(lat);
+        s.setLongitude(lon);
+        for (String line : lines) {
+            s.addLine(line);
+        }
+        return s;
+    }
+
+    @Test
+    void getAllStations_returnsMap() throws Exception {
+        Map<String, StationInfo> map = new LinkedHashMap<>();
+        map.put("stop-1", buildStation("stop-1", "Station One", 1.0, 2.0, "Red"));
+        map.put("stop-2", buildStation("stop-2", "Station Two", 3.0, 4.0, "Blue"));
+        given(stationService.getStationInfo_v2()).willReturn(map);
+
+        mockMvc.perform(get("/api/v1/stations"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.['stop-1'].id").value("stop-1"))
+                .andExpect(jsonPath("$.['stop-2'].name").value("Station Two"));
+    }
+
+    @Test
+    void getStationById_found() throws Exception {
+        StationInfo s = buildStation("stop-1", "Station One", 1.0, 2.0, "Red", "Blue");
+        given(stationService.getStationInfoById("stop-1")).willReturn(s);
+
+        mockMvc.perform(get("/api/v1/stations/stop-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("stop-1"))
+                .andExpect(jsonPath("$.lines.length()").value(2));
+    }
+
+    @Test
+    void getStationById_notFound() throws Exception {
+        given(stationService.getStationInfoById("missing")).willReturn(null);
+
+        mockMvc.perform(get("/api/v1/stations/missing"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getLinesByStation_found() throws Exception {
+        Set<String> lines = new LinkedHashSet<>(Arrays.asList("Red", "Blue"));
+        given(stationService.linesByStation_v2("stop-1")).willReturn(lines);
+
+        mockMvc.perform(get("/api/v1/stations/stop-1/lines"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("Red"))
+                .andExpect(jsonPath("$[1]").value("Blue"));
+    }
+
+    @Test
+    void getLinesByStation_notFoundOrEmpty() throws Exception {
+        given(stationService.linesByStation_v2("stop-2")).willReturn(Collections.emptySet());
+
+        mockMvc.perform(get("/api/v1/stations/stop-2/lines"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/ss/stationapi/service/StationServiceTest.java
+++ b/src/test/java/com/ss/stationapi/service/StationServiceTest.java
@@ -1,0 +1,47 @@
+package com.ss.stationapi.service;
+
+import com.ss.stationapi.model.StationInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StationServiceTest {
+
+    @Test
+    void populateNeighbors_buildsBidirectionalAdjacencyWithNamesAndLines() {
+        StationService service = new StationService();
+        Map<String, StationInfo> stationById = new HashMap<>();
+
+        StationInfo a = new StationInfo();
+        a.setId("A");
+        a.setName("Alpha");
+        StationInfo b = new StationInfo();
+        b.setId("B");
+        b.setName("Bravo");
+        StationInfo c = new StationInfo();
+        c.setId("C");
+        c.setName("Charlie");
+
+        stationById.put("A", a);
+        stationById.put("B", b);
+        stationById.put("C", c);
+
+        LinkedHashSet<String> ordered = new LinkedHashSet<>(Arrays.asList("A", "B", "C"));
+
+        service.populateNeighbors(ordered, "Red", stationById);
+
+        assertThat(a.getNeighbors()).extracting(n -> n.getStationId()).containsExactly("B");
+        assertThat(b.getNeighbors()).extracting(n -> n.getStationId()).containsExactly("A", "C");
+        assertThat(c.getNeighbors()).extracting(n -> n.getStationId()).containsExactly("B");
+
+        assertThat(b.getNeighbors().get(0).getName()).isEqualTo("Alpha");
+        assertThat(b.getNeighbors().get(1).getName()).isEqualTo("Charlie");
+
+        assertThat(a.getNeighbors().get(0).getLines()).contains("Red");
+        assertThat(b.getNeighbors().get(0).getLines()).contains("Red");
+        assertThat(b.getNeighbors().get(1).getLines()).contains("Red");
+        assertThat(c.getNeighbors().get(0).getLines()).contains("Red");
+    }
+}


### PR DESCRIPTION
Add unit and integration tests for API endpoints, making integration tests deterministic by mocking the service.

Integration tests now use a mocked `StationService` to ensure deterministic and reliable execution without relying on external MBTA API calls. New unit tests cover controller and service logic in isolation.

---
<a href="https://cursor.com/background-agent?bcId=bc-dae4eacd-0622-404b-acd2-56771514822c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dae4eacd-0622-404b-acd2-56771514822c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

